### PR TITLE
Fixes image size for related pathways

### DIFF
--- a/src/app/issuer/issuer-detail.component.ts
+++ b/src/app/issuer/issuer-detail.component.ts
@@ -161,7 +161,7 @@ import { ExternalToolsManager } from "app/externaltools/services/externaltools-m
 
 					<div *bgAwaitPromises="[issuerLoaded, pathwaysLoaded]" class="l-gridthree">
 						<div *ngFor="let pathway of pathways">
-							<div class="card">
+							<div class="card card-smallimage">
 								<a class="card-x-main"
 								   [routerLink]="['/issuer/issuers', issuerSlug, 'pathways', pathway.slug, 'elements', pathway.slug]">
 									<div class="card-x-image">

--- a/src/breakdown/static/scss/modules/card/_card.scss
+++ b/src/breakdown/static/scss/modules/card/_card.scss
@@ -190,6 +190,14 @@
 
 }
 
+.card-smallimage {
+  .card-x-image {
+    img {
+      width: 40px;
+    }
+  }
+}
+
 // Used on pathway detail to align a single action to the right of the card
 
 .card-actionsright {


### PR DESCRIPTION
Fixes this display issue, with new `card-smallimage`

<img width="1158" alt="screen shot 2018-09-19 at 1 15 37 pm" src="https://user-images.githubusercontent.com/857356/45782000-7a2ef400-bc16-11e8-9afd-e3dd1bcecc85.png">
