### PR TITLE
fixed issue where verify-prod-environment didn't work on Ubuntu

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"start": "ng serve",
 		"start-intellij": "ng serve --host 0.0.0.0 --disable-host-check --aot 2>&1 | perl -e '$|++; while (<>) { s/((ERROR|WARNING) in\\s*)(.*)/$1\\n$3/g; print $_; }'",
 		"build:widgets": "webpack --config widgets-webpack.config.ts",
-		"verify-prod-environment": "[[ -f src/environments/environment.prod.ts ]] || (echo '\\033[0;31m!!!'; echo '\\033[0;31m!!! No envrionment.prod.ts file present. Copy environment.prod.ts.example and modify it for your environment or consult the README'; echo '\\033[0;31m!!!'; echo; exit -1)",
+		"verify-prod-environment": "if [ ! -f src/environments/environment.prod.ts ]; then echo '\\033[0;31m!!!'; echo '\\033[0;31m!!! No envrionment.prod.ts file present. Copy environment.prod.ts.example and modify it for your environment or consult the README'; echo '\\033[0;31m!!!'; echo; exit -1; fi",
 		"build:app": "npm run verify-prod-environment && ng build --output-hashing=all --aot --prod && html-minifier -c html-minifier.config.json -o dist/index.html < dist/index.html",
 		"build": "npm run build:app && npm run build:widgets",
 		"test": "ng test",


### PR DESCRIPTION
When I ran `npm run verify-prod-environment` on Ubuntu 18.04, it didn't work because it didn't recognize `[[` as a `sh` command.  I fixed this by using a good ole if statement.

Here's the error:
![image](https://user-images.githubusercontent.com/4313463/65838779-b6d70600-e2d4-11e9-8602-af7508bd5d09.png)

Here is the `npm run verify-prod-environment` running successfully on Ubuntu 18.04:
![image](https://user-images.githubusercontent.com/4313463/65838801-e423b400-e2d4-11e9-8cb9-ff15565e5237.png)

I will attach below an image of it working on MacOS:


Let me know if there is anything that you would like changed.